### PR TITLE
Make scheduled jobs configurable on deploy

### DIFF
--- a/quarkus-chart/values.yaml
+++ b/quarkus-chart/values.yaml
@@ -69,6 +69,8 @@ deploy:
         S3MIRROR_S3_ENDPOINT_OVERRIDE: "http://<s3-minio-override>:9001"
         S3MIRROR_S3_ACCESS_KEY_ID: "changeme"
         S3MIRROR_S3_SECRET_ACCESS_KEY: "changeme"
+        S3MIRROR_SCHEDULE_INDEXER: "0 0/7 * * * ?"
+        S3MIRROR_SCHEDULE_MIRROR: "0 0/3 * * * ?"
 
 
 

--- a/src/main/java/com/nephele/service/RedisIndexer.java
+++ b/src/main/java/com/nephele/service/RedisIndexer.java
@@ -79,7 +79,7 @@ public class RedisIndexer {
         todayDateTime = ZonedDateTime.of(today, utc);
     }
 
-    @Scheduled(cron="0 0/7 * * * ?")
+    @Scheduled(cron="{s3mirror.schedule.indexer}")
     public void indexMain() throws JsonProcessingException {
         if(indexMode){
             index();

--- a/src/main/java/com/nephele/service/mirror/MirrorMain.java
+++ b/src/main/java/com/nephele/service/mirror/MirrorMain.java
@@ -92,7 +92,7 @@ public class MirrorMain {
     public MirrorMain() {
     }
 
-    @Scheduled(cron="0 0/3 * * * ?")
+    @Scheduled(cron="{s3mirror.schedule.mirror}")
     public void mirrorMain() throws Exception {
         ensureInit();
         if(mirrorMode){

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -8,7 +8,7 @@ s3mirror.s3.access-key-id=""
 s3mirror.s3.secret-access-key=""
 s3mirror.s3.endpoint-override=http://localhost:9001
 
-cron.index=0 0/45 * * * ?
+s3mirror.schedule.indexer=0 0/45 * * * ?
 
 # Quarkus configs
 quarkus.swagger-ui.always-include=true

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -9,6 +9,7 @@ s3mirror.s3.secret-access-key=""
 s3mirror.s3.endpoint-override=http://localhost:9001
 
 s3mirror.schedule.indexer=0 0/45 * * * ?
+s3mirror.schedule.mirror=0 0/3 * * * ?
 
 # Quarkus configs
 quarkus.swagger-ui.always-include=true


### PR DESCRIPTION
Move configuration of mirror and index job schedule to config file. 
Allows user deploying to override the frequency of the index and mirror jobs to match use cases and frequency requirements. 